### PR TITLE
Update README.md to correct an error to generate the image embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ transformer = get_custom_transformer('GPFM')
 img = Image.open('img/path') # we prefer image with size of 512*512 (extracted from 40X)
 img = transformer(img) 
 img = img[None] # to 4D tensor
+img = img.cuda() # load images into gpu
 feat = model(img) # [N, 1024]
 
 ```


### PR DESCRIPTION
Hi, thanks for your work. I found that there is an issue when loading the image with current example code:

```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```

I covert the image to cuda version and it resolved this problem. If you think it is helpful, please consider merging it. Thanks.